### PR TITLE
Use https in wraps.

### DIFF
--- a/wrapcreator.py
+++ b/wrapcreator.py
@@ -45,7 +45,7 @@ class UpstreamDefinition:
 
 class WrapCreator:
     def __init__(self, name, repo_url, branch, out_dir='.',
-                 out_url_base='http://wrapdb.mesonbuild.com/v1/projects/%s/%s/%d/get_zip'):
+                 out_url_base='https://wrapdb.mesonbuild.com/v1/projects/%s/%s/%d/get_zip'):
         self.name = name
         self.repo_url = repo_url
         self.branch = branch


### PR DESCRIPTION
Existing wraps will use http until new versions of them are pushed. This will happen automatically as they are pushed.

Plain http urls keep on working and can be used by people who are behind strict firewalls but they need to edit wrap files by hand.