### PR TITLE
Get rid of commit zero

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 sudo: false
 
 python:
+  - "3.5"
   - "3.6"
 
 install:

--- a/run_integration_tests.py
+++ b/run_integration_tests.py
@@ -101,7 +101,7 @@ class FakeProject:
         return self.builder.repo
 
 
-class ToolsTest(unittest.TestCase):
+class IntegrationTestBase(unittest.TestCase):
 
     def setUp(self):
         try:
@@ -127,6 +127,9 @@ class ToolsTest(unittest.TestCase):
             if v['branch'] == project.version and v['revision'] == project.revision:
                 return
         self.fail('{!r} not found'.format(project))
+
+
+class WrapUpdaterTest(IntegrationTestBase):
 
     def wrapupdater(self, name, url, version):
         subprocess.check_call(args=WRAPUPDATER + [name, url, version])

--- a/run_integration_tests.py
+++ b/run_integration_tests.py
@@ -59,7 +59,7 @@ class Server(subprocess.Popen):
             return r.read()
 
     def fetch_json(self, addr):
-        j = json.loads(self.fetch(addr))
+        j = json.loads(self.fetch(addr).decode('utf8'))
         if j['output'] != 'ok':
             raise ValueError('Bad server response')
         return j

--- a/run_integration_tests.py
+++ b/run_integration_tests.py
@@ -190,6 +190,19 @@ class ToolsTest(unittest.TestCase):
         self.wrapupdater(f.name, f.url, '1.0.0')
         self.assertUploaded(Project(f.name, '1.0.0', 6))
 
+    def test_wrapupdater_latest_revision_only(self):
+        f = FakeProject('test3', self.tmpdir)
+        f.create_version('1.0.0')
+        f.commit('revision 2')
+        f.create_version('1.0.1', base='1.0.0', message='New [wrap version]')
+        f.commit('revision 2')
+        f.commit('revision 3')
+        f.commit('revision 4')
+        self.wrapupdater(f.name, f.url, '1.0.0')
+        self.wrapupdater(f.name, f.url, '1.0.1')
+        self.assertUploaded(Project(f.name, '1.0.0', 2))
+        self.assertUploaded(Project(f.name, '1.0.1', 4))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/run_integration_tests.py
+++ b/run_integration_tests.py
@@ -128,10 +128,13 @@ class ToolsTest(unittest.TestCase):
                 return
         self.fail('{!r} not found'.format(project))
 
+    def wrapupdater(self, name, url, version):
+        subprocess.check_call(args=WRAPUPDATER + [name, url, version])
+
     def test_existing_wrapupdater(self):
         for project in projects:
             url = 'https://github.com/mesonbuild/{name}.git'.format(name=project.name)
-            subprocess.check_call(args=WRAPUPDATER + [project.name, url, project.version])
+            self.wrapupdater(project.name, url, project.version)
             self.assertIn(project.name, self.server.projects())
             self.assertLooseUploaded(project)
 
@@ -139,8 +142,8 @@ class ToolsTest(unittest.TestCase):
         f = FakeProject('test1', self.tmpdir)
         f.create_version('1.0.0')
         f.create_version('1.0.1')
-        subprocess.check_call(args=WRAPUPDATER + [f.name, f.url, '1.0.0'])
-        subprocess.check_call(args=WRAPUPDATER + [f.name, f.url, '1.0.1'])
+        self.wrapupdater(f.name, f.url, '1.0.0')
+        self.wrapupdater(f.name, f.url, '1.0.1')
         self.assertIn(f.name, self.server.projects())
         self.assertUploaded(Project(f.name, '1.0.0', 1))
         self.assertUploaded(Project(f.name, '1.0.1', 1))
@@ -148,20 +151,20 @@ class ToolsTest(unittest.TestCase):
     def test_wrapupdater_revisions(self):
         f = FakeProject('test2', self.tmpdir)
         f.create_version('1.0.0')
-        subprocess.check_call(args=WRAPUPDATER + [f.name, f.url, '1.0.0'])
+        self.wrapupdater(f.name, f.url, '1.0.0')
         f.commit('update')
-        subprocess.check_call(args=WRAPUPDATER + [f.name, f.url, '1.0.0'])
+        self.wrapupdater(f.name, f.url, '1.0.0')
         self.assertUploaded(Project(f.name, '1.0.0', 1))
         self.assertUploaded(Project(f.name, '1.0.0', 2))
 
     def test_wrapupdater_branched_revisions(self):
         f = FakeProject('test3', self.tmpdir)
         f.create_version('1.0.0')
-        subprocess.check_call(args=WRAPUPDATER + [f.name, f.url, '1.0.0'])
+        self.wrapupdater(f.name, f.url, '1.0.0')
         f.create_version('1.0.1', base='1.0.0', message='New [wrap version]')
-        subprocess.check_call(args=WRAPUPDATER + [f.name, f.url, '1.0.1'])
+        self.wrapupdater(f.name, f.url, '1.0.1')
         f.commit('another commit')
-        subprocess.check_call(args=WRAPUPDATER + [f.name, f.url, '1.0.1'])
+        self.wrapupdater(f.name, f.url, '1.0.1')
         self.assertUploaded(Project(f.name, '1.0.0', 1))
         self.assertUploaded(Project(f.name, '1.0.1', 1))
         self.assertUploaded(Project(f.name, '1.0.1', 2))
@@ -169,22 +172,22 @@ class ToolsTest(unittest.TestCase):
     def test_wrapupdater_merged_revisions(self):
         f = FakeProject('test', self.tmpdir)
         f.create_version('1.0.0')
-        subprocess.check_call(args=WRAPUPDATER + [f.name, f.url, '1.0.0'])
+        self.wrapupdater(f.name, f.url, '1.0.0')
         self.assertUploaded(Project(f.name, '1.0.0', 1))
         f.repo.index.commit('commit 1')
-        subprocess.check_call(args=WRAPUPDATER + [f.name, f.url, '1.0.0'])
+        self.wrapupdater(f.name, f.url, '1.0.0')
         self.assertUploaded(Project(f.name, '1.0.0', 2))
         p = f.repo.index.commit('commit 2')
-        subprocess.check_call(args=WRAPUPDATER + [f.name, f.url, '1.0.0'])
+        self.wrapupdater(f.name, f.url, '1.0.0')
         self.assertUploaded(Project(f.name, '1.0.0', 3))
         f.repo.index.commit('commit 3')
-        subprocess.check_call(args=WRAPUPDATER + [f.name, f.url, '1.0.0'])
+        self.wrapupdater(f.name, f.url, '1.0.0')
         self.assertUploaded(Project(f.name, '1.0.0', 4))
         f.repo.index.commit('commit 4', parent_commits=(p, f.repo.head.commit))
-        subprocess.check_call(args=WRAPUPDATER + [f.name, f.url, '1.0.0'])
+        self.wrapupdater(f.name, f.url, '1.0.0')
         self.assertUploaded(Project(f.name, '1.0.0', 5))
         f.repo.index.commit('commit 5', parent_commits=(p, f.repo.head.commit))
-        subprocess.check_call(args=WRAPUPDATER + [f.name, f.url, '1.0.0'])
+        self.wrapupdater(f.name, f.url, '1.0.0')
         self.assertUploaded(Project(f.name, '1.0.0', 6))
 
 

--- a/run_integration_tests.py
+++ b/run_integration_tests.py
@@ -90,7 +90,11 @@ class FakeProject:
         self.builder.repo.index.commit(message)
 
     def commit(self, message):
-        self.builder.repo.index.commit(message)
+        return self.builder.repo.index.commit(message)
+
+    def merge_commit(self, message, parent):
+        return self.builder.repo.index.commit(
+            message, parent_commits=(self.builder.repo.head.commit, parent))
 
     @property
     def url(self):
@@ -177,19 +181,19 @@ class WrapUpdaterTest(IntegrationTestBase):
         f.create_version('1.0.0')
         self.wrapupdater(f.name, f.url, '1.0.0')
         self.assertUploaded(Project(f.name, '1.0.0', 1))
-        f.repo.index.commit('commit 1')
+        f.commit('commit 1')
         self.wrapupdater(f.name, f.url, '1.0.0')
         self.assertUploaded(Project(f.name, '1.0.0', 2))
-        p = f.repo.index.commit('commit 2')
+        p = f.commit('commit 2')
         self.wrapupdater(f.name, f.url, '1.0.0')
         self.assertUploaded(Project(f.name, '1.0.0', 3))
-        f.repo.index.commit('commit 3')
+        f.commit('commit 3')
         self.wrapupdater(f.name, f.url, '1.0.0')
         self.assertUploaded(Project(f.name, '1.0.0', 4))
-        f.repo.index.commit('commit 4', parent_commits=(p, f.repo.head.commit))
+        f.merge_commit('commit 4', parent=p)
         self.wrapupdater(f.name, f.url, '1.0.0')
         self.assertUploaded(Project(f.name, '1.0.0', 5))
-        f.repo.index.commit('commit 5', parent_commits=(p, f.repo.head.commit))
+        f.merge_commit('commit 5', parent=p)
         self.wrapupdater(f.name, f.url, '1.0.0')
         self.assertUploaded(Project(f.name, '1.0.0', 6))
 

--- a/tools/repoinit.py
+++ b/tools/repoinit.py
@@ -87,8 +87,6 @@ class RepoBuilder:
         with self.open('LICENSE.build', 'w') as ofile:
             ofile.write(mit_license.format(year=datetime.datetime.now().year))
         self.commit = self.repo.index.commit('Created repository for project %s.' % name)
-        self.tag = self.repo.create_tag('commit_zero', self.commit,
-                                        message=' tag that helps get revision ids for releases.')
 
     def open(self, path, mode='r'):
         abspath = os.path.join(self.repo.working_dir, path)
@@ -102,7 +100,6 @@ class RepoBuilder:
             remote = 'git@github.com:mesonbuild/%s.git' % self.name
         origin = self.repo.create_remote('origin', remote)
         origin.push(self.repo.head.ref.name)
-        origin.push(self.tag)
 
     @staticmethod
     def _get_hash(url):

--- a/tools/reviewtool.py
+++ b/tools/reviewtool.py
@@ -42,22 +42,15 @@ class Reviewer:
         self._pull = self._project.get_pull(pull_id)
 
     def review(self):
-        with tempfile.TemporaryDirectory() as base_dir:
-            with tempfile.TemporaryDirectory() as head_dir:
-                self.review_int(base_dir, head_dir)
+        with tempfile.TemporaryDirectory() as head_dir:
+            self.review_int(head_dir)
 
-    def clone_repos(self, base_dir, head_dir):
-        base_git = self._pull.base.repo.clone_url
-        head_git = self._pull.head.repo.clone_url
-        base_repo = git.Repo.clone_from(base_git, base_dir, branch=self._pull.base.ref)
-        head_repo = git.Repo.clone_from(head_git, head_dir, branch=self._pull.head.ref)
-        return (base_repo, head_repo)
-
-    def review_int(self, base_dir, head_dir):
+    def review_int(self, head_dir):
         project = self._pull.base.repo.name
         branch = self._pull.base.ref
-        base_repo, head_repo = self.clone_repos(base_dir, head_dir)
-        if not self.check_basics(base_repo, head_repo, project, branch): return False
+        head_repo = git.Repo.clone_from(self._pull.head.repo.clone_url, head_dir,
+                                        branch=self._pull.head.ref)
+        if not self.check_basics(head_repo, project, branch): return False
         if not self.check_files(head_dir): return False
         if not self.check_wrapformat(os.path.join(head_dir, 'upstream.wrap')): return False
         if not self.check_download(os.path.join(head_dir, 'upstream.wrap')): return False
@@ -101,13 +94,12 @@ class Reviewer:
     def isfile(head_dir, filename):
         return os.path.isfile(os.path.join(head_dir, filename))
 
-    def check_basics(self, base_repo, head_repo, project, branch):
+    def check_basics(self, head_repo, project, branch):
         print('Inspecting project %s, branch %s.' % (project, branch))
         head_dir = head_repo.working_dir
         if not print_status('Repo name valid', re.fullmatch('[a-z0-9._]+', project)): return False
         if not print_status('Branch name valid', re.fullmatch('[a-z0-9._]+', branch)): return False
         if not print_status('Target branch is not master', branch != 'master'): return False
-        if not print_status('Has commit_zero', 'commit_zero' in self.git_tags(base_repo)): return False
         if not print_status('Has readme.txt', self.isfile(head_dir, 'readme.txt')): return False
         if not print_status('Has LICENSE.build', self.isfile(head_dir, 'LICENSE.build')): return False
         if not print_status('Has upstream.wrap', self.isfile(head_dir, 'upstream.wrap')): return False

--- a/wrapcreator.py
+++ b/wrapcreator.py
@@ -57,12 +57,16 @@ class WrapCreator:
         with tempfile.TemporaryDirectory() as workdir:
             return self.create_internal(workdir)
 
+    @staticmethod
+    def _get_revision(repo):
+        revision_str = repo.git.describe()
+        return int(revision_str.split('-')[1])
+
     def create_internal(self, workdir):
         repo = git.Repo.clone_from(self.repo_url, workdir, branch=self.branch)
         upstream_file = os.path.join(workdir, 'upstream.wrap')
         upstream_content = open(upstream_file).read()
-        revision_str = repo.git.describe()
-        revision_id = int(revision_str.split('-')[1])
+        revision_id = self._get_revision(repo)
         self.upstream_file = os.path.join(workdir, 'upstream.wrap')
         self.definition = UpstreamDefinition(self.upstream_file)
         shutil.rmtree(os.path.join(workdir, '.git'))


### PR DESCRIPTION
Closes #30 

Revision is calculated as number of commits above latest `[wrap version]`-tagged commit with `upstream.build` present.

@textshell please take a look, this is partially your idea :)