### PR TITLE
Distinguish between undetermined failures and API errors

### DIFF
--- a/mesonwrap/wrapdb.py
+++ b/mesonwrap/wrapdb.py
@@ -59,15 +59,19 @@ class WrapDatabase:
         return (version.LooseVersion(version_tuple[0]), version_tuple[1])
 
     def get_versions(self, project, latest=False):
+        """Returns empty list if project does not exist."""
         c = self.conn.cursor()
         query = '''SELECT branch, revision FROM wraps
                    WHERE project == ?;'''
         c.execute(query, (project,))
+        results = c.fetchall()
+        if not results:
+            return []
         if latest:
             # TODO consider computing this during import
-            return [max(c.fetchall(), key=self._version_key)]
+            return [max(results, key=self._version_key)]
         else:
-            return sorted(c.fetchall(), key=self._version_key, reverse=True)
+            return sorted(results, key=self._version_key, reverse=True)
 
     def get_wrap(self, project, branch, revision):
         c = self.conn.cursor()

--- a/run_integration_tests.py
+++ b/run_integration_tests.py
@@ -207,6 +207,10 @@ class QueryTest(IntegrationTestBase):
             self.wrapupdater(f.name, f.url, version)
         self.assertLatest(f.name, '17a', 1)
 
+    def test_latest_does_not_exist(self):
+        with self.assertRaisesRegex(webapi.APIError, 'No such project'):
+            self.server.api._api.query_v1_get_latest('non-existent-project')
+
     def test_by_name_prefix(self):
         baz = FakeProject('baz', self.tmpdir)
         baz.create_version('1.0.0')

--- a/wrapweb/api.py
+++ b/wrapweb/api.py
@@ -44,7 +44,7 @@ def name_query(project):
 def get_latest(project):
     matches = _database().get_versions(project, latest=True)
     if len(matches) == 0:
-        return jsonstatus.error(500, 'No such project')
+        return jsonstatus.error(404, 'No such project')
     latest = matches[0]
     return jsonstatus.ok(branch=latest[0], revision=latest[1])
 
@@ -56,7 +56,7 @@ def get_project_info(project):
         return get_projectlist()
     matches = _database().get_versions(project)
     if len(matches) == 0:
-        return jsonstatus.error(500, 'No such project')
+        return jsonstatus.error(404, 'No such project')
     versions = [{'branch': i[0], 'revision': i[1]} for i in matches]
     return jsonstatus.ok(versions=versions)
 
@@ -65,7 +65,7 @@ def get_project_info(project):
 def get_wrap(project, branch, revision):
     result = _database().get_wrap(project, branch, revision)
     if result is None:
-        return jsonstatus.error(500, 'No such entry')
+        return jsonstatus.error(404, 'No such entry')
     resp = flask.make_response(result)
     resp.mimetype = 'text/plain'
     return resp
@@ -75,7 +75,7 @@ def get_wrap(project, branch, revision):
 def get_zip(project, branch, revision):
     result = _database().get_zip(project, branch, revision)
     if result is None:
-        return jsonstatus.error(500, 'No such entry')
+        return jsonstatus.error(404, 'No such entry')
     resp = flask.make_response(result)
     resp.mimetype = 'application/zip'
     resp.headers['Content-Disposition'] = (


### PR DESCRIPTION
Return 404 if project is not found. It is not an internal server error.
Introduce a separate error class webapi.APIError() to report them.
Fix #59: return no results form database wrapper if project is not found.
Add a single test case for #59. TODO: test more cases.

This is technically an API change since 404 is returned instead of 500 in some cases, @jpakkane please take a look.